### PR TITLE
fix: Resolve repeated AttributeError in new GUI

### DIFF
--- a/src/gui/new_app.py
+++ b/src/gui/new_app.py
@@ -87,7 +87,7 @@ class ChessPilotGUI(tk.Frame):
         self.transparency_var = tk.DoubleVar(value=1.0)
         transparency_frame = tk.Frame(controls_frame, bg=self.frame_color)
         tk.Label(transparency_frame, text="Transparency:", font=('Segoe UI', 10), bg=self.frame_color, fg=self.text_color).pack(side=tk.LEFT, padx=5)
-        self.transparency_slider = ttk.Scale(transparency_frame, from_=0.2, to=1.0, variable=self.transparency_var, command=self.master.set_transparency)
+        self.transparency_slider = ttk.Scale(transparency_frame, from_=0.2, to=1.0, variable=self.transparency_var)
         self.transparency_slider.pack(side=tk.LEFT, fill=tk.X, expand=True)
         transparency_frame.pack(fill=tk.X, pady=5)
 


### PR DESCRIPTION
This commit fixes a second instance of a critical bug that caused an `AttributeError` when interacting with the GUI. The previous fix for the 'Auto Play' checkbox was not applied to the 'Transparency' slider.

The error occurred because the command for the slider was incorrectly wired to the main Tkinter window instead of the `ChessPilot` application instance.

The fix involves:
- Removing the `command` assignment from the `ttk.Scale` widget creation in `src/gui/new_app.py`.
- The command is already correctly bound in `src/main.py`, so no changes were needed there.

This ensures that all GUI events are now properly handled by the application logic, preventing the `AttributeError` from recurring.